### PR TITLE
fix(config): add default version to avoid validation warnings

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -97,7 +97,9 @@ class ConfigManager:
             yaml.YAMLError: If configuration files contain invalid YAML
             jsonschema.ValidationError: If configuration doesn't match schema
         """
-        merged_config = {}
+        merged_config = {
+            'version': '1.0'  # Default version to satisfy schema requirement
+        }
         
         # Load configurations in priority order (lowest to highest)
         # 1. Default configuration (lowest priority)


### PR DESCRIPTION
Resolves #19

Añade la versión por defecto en `load_hierarchical_config` para satisfacer el esquema y evitar los warnings molestos de Pytest.

**Épica Referencia**: #18