### PR TITLE
test(git): update mocks to match current implementation

### DIFF
--- a/tests/test_git_interface.py
+++ b/tests/test_git_interface.py
@@ -354,13 +354,14 @@ class TestGetUnstagedFiles:
             # First call (git status) succeeds, second call (git diff) succeeds
             mock_run.side_effect = [
                 MagicMock(returncode=0),  # git status
-                MagicMock(returncode=0, stdout="file1.py\nfile2.py\n")  # git diff
+                MagicMock(returncode=0, stdout="file1.py\nfile2.py\n"),  # git diff
+                MagicMock(returncode=0, stdout="file3.py\n")  # git ls-files for untracked
             ]
             git = GitInterface()
             result = git.get_unstaged_files()
-            assert result == ["file1.py", "file2.py"]
+            assert result == ["file1.py", "file2.py", "file3.py"]
             # Verify git diff was called
-            assert mock_run.call_count == 2
+            assert mock_run.call_count == 3
             assert mock_run.call_args_list[1] == (
                 (['git', 'diff', '--name-only'],),
                 {'capture_output': True, 'text': True, 'timeout': 10}

--- a/tests/test_git_interface_merge.py
+++ b/tests/test_git_interface_merge.py
@@ -14,131 +14,131 @@ from src.core.git import GitInterface, GitInterfaceError, GitCommandError, NotGi
 
 class TestGitInterfaceMerge:
     """Test GitInterface merge methods."""
-    
+
     def test_merge_branch_success(self):
         """Test successful merge_branch."""
         git = GitInterface()
-        
+
         with patch.object(git, 'is_git_repository', return_value=True):
             with patch('subprocess.run') as mock_run:
                 mock_run.return_value.returncode = 0
                 mock_run.return_value.stderr = ""
-                
+
                 result = git.merge_branch("feature/test")
-                
+
                 assert result is True
-                mock_run.assert_called_once_with(['git', 'merge', 'feature/test'], capture_output=True, text=True)
-    
+                mock_run.assert_called_once_with(['git', 'merge', '--no-ff', '--no-edit', 'feature/test'], capture_output=True, text=True)
+
     def test_merge_branch_not_git_repo(self):
         """Test merge_branch when not in git repository."""
         git = GitInterface()
-        
+
         with patch.object(git, 'is_git_repository', return_value=False):
             with pytest.raises(NotGitRepositoryError, match="Not a git repository"):
                 git.merge_branch("feature/test")
-    
+
     def test_merge_branch_command_error(self):
         """Test merge_branch when git command fails."""
         git = GitInterface()
-        
+
         with patch.object(git, 'is_git_repository', return_value=True):
             with patch('subprocess.run') as mock_run:
                 mock_run.return_value.returncode = 1
                 mock_run.return_value.stderr = "Merge conflict"
-                
+
                 with pytest.raises(GitCommandError, match="Git merge failed"):
                     git.merge_branch("feature/test")
-    
+
     def test_merge_abort_success(self):
         """Test successful merge_abort."""
         git = GitInterface()
-        
+
         with patch.object(git, 'is_git_repository', return_value=True):
             with patch('subprocess.run') as mock_run:
                 mock_run.return_value.returncode = 0
                 mock_run.return_value.stderr = ""
-                
+
                 result = git.merge_abort()
-                
+
                 assert result is True
                 mock_run.assert_called_once_with(['git', 'merge', '--abort'], capture_output=True, text=True)
-    
+
     def test_merge_abort_not_git_repo(self):
         """Test merge_abort when not in git repository."""
         git = GitInterface()
-        
+
         with patch.object(git, 'is_git_repository', return_value=False):
             with pytest.raises(NotGitRepositoryError, match="Not a git repository"):
                 git.merge_abort()
-    
+
     def test_merge_abort_command_error(self):
         """Test merge_abort when git command fails."""
         git = GitInterface()
-        
+
         with patch.object(git, 'is_git_repository', return_value=True):
             with patch('subprocess.run') as mock_run:
                 mock_run.return_value.returncode = 1
                 mock_run.return_value.stderr = "No merge in progress"
-                
+
                 with pytest.raises(GitCommandError, match="Git merge --abort failed"):
                     git.merge_abort()
-    
+
     def test_merge_continue_success(self):
         """Test successful merge_continue."""
         git = GitInterface()
-        
+
         with patch.object(git, 'is_git_repository', return_value=True):
             with patch('subprocess.run') as mock_run:
                 mock_run.return_value.returncode = 0
                 mock_run.return_value.stderr = ""
-                
+
                 result = git.merge_continue()
-                
+
                 assert result is True
                 mock_run.assert_called_once_with(['git', 'merge', '--continue'], capture_output=True, text=True)
-    
+
     def test_merge_continue_not_git_repo(self):
         """Test merge_continue when not in git repository."""
         git = GitInterface()
-        
+
         with patch.object(git, 'is_git_repository', return_value=False):
             with pytest.raises(NotGitRepositoryError, match="Not a git repository"):
                 git.merge_continue()
-    
+
     def test_merge_continue_command_error(self):
         """Test merge_continue when git command fails."""
         git = GitInterface()
-        
+
         with patch.object(git, 'is_git_repository', return_value=True):
             with patch('subprocess.run') as mock_run:
                 mock_run.return_value.returncode = 1
                 mock_run.return_value.stderr = "No merge in progress"
-                
+
                 with pytest.raises(GitCommandError, match="Git merge --continue failed"):
                     git.merge_continue()
-    
+
     def test_merge_branch_subprocess_error(self):
         """Test merge_branch when subprocess raises CalledProcessError."""
         git = GitInterface()
-        
+
         with patch.object(git, 'is_git_repository', return_value=True):
             with patch('subprocess.run', side_effect=subprocess.CalledProcessError(1, 'git')):
                 with pytest.raises(GitCommandError, match="Git merge failed"):
                     git.merge_branch("feature/test")
-    
+
     def test_merge_abort_subprocess_error(self):
         """Test merge_abort when subprocess raises CalledProcessError."""
         git = GitInterface()
-        
+
         with patch.object(git, 'is_git_repository', return_value=True):
             with patch('subprocess.run', side_effect=subprocess.CalledProcessError(1, 'git')):
                 with pytest.raises(GitCommandError, match="Git merge --abort failed"):
                     git.merge_abort()
-    
+
     def test_merge_continue_subprocess_error(self):
         """Test merge_continue when subprocess raises CalledProcessError."""
         git = GitInterface()
-        
+
         with patch.object(git, 'is_git_repository', return_value=True):
             with patch('subprocess.run', side_effect=subprocess.CalledProcessError(1, 'git')):
                 with pytest.raises(GitCommandError, match="Git merge --continue failed"):


### PR DESCRIPTION
Resolves #20

- Se actualizó el mock en `test_git_interface_merge.py` para esperar las flags `--no-ff` y `--no-edit`.
- Se añadieron más iteraciones al `side_effect` del mock en `test_git_interface.py` para evitar `StopIteration` cuando se ejecuta el comando de búsqueda de untracked files.
- Se ajustaron las aserciones (`call_count` a 3).

**Épica Referencia**: #18