### PR TITLE
fix(test): resolve Pytest I/O error caused by logger and sync conventional commit mocks

### DIFF
--- a/src/core/utils/logging.py
+++ b/src/core/utils/logging.py
@@ -85,8 +85,12 @@ class LoggingManager:
         root_logger = logging.getLogger('gggit')
         root_logger.setLevel(getattr(logging, self.log_level.upper()))
         
-        # Clear any existing handlers
-        root_logger.handlers.clear()
+        # Clear any existing handlers to prevent duplicates
+        for handler in root_logger.handlers[:]:
+            root_logger.removeHandler(handler)
+            
+        # Prevent propagation to avoid duplicate logs in pytest output
+        root_logger.propagate = False
         
         # Create formatter
         formatter = logging.Formatter(
@@ -109,7 +113,8 @@ class LoggingManager:
         root_logger.addHandler(error_handler)
         
         # Console handler
-        console_handler = logging.StreamHandler()
+        import sys
+        console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setLevel(getattr(logging, self.log_level.upper()))
         console_handler.setFormatter(formatter)
         root_logger.addHandler(console_handler)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -345,9 +345,22 @@ def test_helpers():
     return TestHelpers
 
 
-# ============================================================================
-# Pytest Configuration
-# ============================================================================
+@pytest.fixture(autouse=True)
+def clean_logging_handlers():
+    """Ensure all logging handlers are closed after each test to prevent I/O errors."""
+    yield
+    import logging
+    
+    # Close all handlers on the gggit root logger
+    root_logger = logging.getLogger('gggit')
+    for handler in list(root_logger.handlers):
+        handler.close()
+        root_logger.removeHandler(handler)
+    
+    # Also clean up standard library root logger just in case
+    for handler in list(logging.root.handlers):
+        handler.close()
+        logging.root.removeHandler(handler)
 
 def pytest_configure(config):
     """Configure pytest with custom markers."""

--- a/tests/test_conventional_commits_basic.py
+++ b/tests/test_conventional_commits_basic.py
@@ -45,79 +45,55 @@ class TestBasicConventionalCommitsExecute:
         """Test successful execution for all commands."""
         cmd = command_class()
         
-        with patch(f'src.commands.{command_name}.CommitCommand') as mock_commit_class:
-            mock_commit = MagicMock()
-            mock_commit.execute.return_value = 0
-            mock_commit_class.return_value = mock_commit
+        with patch.object(cmd, '_execute_manual_commit', return_value=0) as mock_execute:
+            result = cmd.execute("test message")
             
-            with patch(f'src.commands.{command_name}.ColorManager.success') as mock_success:
-                result = cmd.execute("test message")
-                
-                assert result == 0
-                mock_commit_class.assert_called_once_with(commit_type)
-                mock_commit.execute.assert_called_once_with("test message", None, False)
-                mock_success.assert_called_once_with("Commit realizado exitosamente")
+            assert result == 0
+            mock_execute.assert_called_once_with("test message", None, False)
     
     @pytest.mark.parametrize("command_class,commit_type,main_func,command_name", COMMAND_TEST_DATA)
     def test_execute_with_scope(self, command_class, commit_type, main_func, command_name):
         """Test execution with scope for all commands."""
         cmd = command_class()
         
-        with patch(f'src.commands.{command_name}.CommitCommand') as mock_commit_class:
-            mock_commit = MagicMock()
-            mock_commit.execute.return_value = 0
-            mock_commit_class.return_value = mock_commit
+        with patch.object(cmd, '_execute_manual_commit', return_value=0) as mock_execute:
+            result = cmd.execute("test message", scope="api")
             
-            with patch(f'src.commands.{command_name}.ColorManager.success') as mock_success:
-                result = cmd.execute("test message", scope="api")
-                
-                assert result == 0
-                mock_commit.execute.assert_called_once_with("test message", "api", False)
-                mock_success.assert_called_once_with("Commit realizado exitosamente")
+            assert result == 0
+            mock_execute.assert_called_once_with("test message", "api", False)
     
     @pytest.mark.parametrize("command_class,commit_type,main_func,command_name", COMMAND_TEST_DATA)
     def test_execute_with_amend(self, command_class, commit_type, main_func, command_name):
         """Test execution with amend for all commands."""
         cmd = command_class()
         
-        with patch(f'src.commands.{command_name}.CommitCommand') as mock_commit_class:
-            mock_commit = MagicMock()
-            mock_commit.execute.return_value = 0
-            mock_commit_class.return_value = mock_commit
+        with patch.object(cmd, '_execute_manual_commit', return_value=0) as mock_execute:
+            result = cmd.execute("test message", amend=True)
             
-            with patch(f'src.commands.{command_name}.ColorManager.success') as mock_success:
-                result = cmd.execute("test message", amend=True)
-                
-                assert result == 0
-                mock_commit.execute.assert_called_once_with("test message", None, True)
-                mock_success.assert_called_once_with("Commit realizado exitosamente")
-    
+            assert result == 0
+            mock_execute.assert_called_once_with("test message", None, True)
+
     @pytest.mark.parametrize("command_class,commit_type,main_func,command_name", COMMAND_TEST_DATA)
     def test_execute_with_ai_flag(self, command_class, commit_type, main_func, command_name):
-        """Test execution with AI flag (not implemented) for all commands."""
+        """Test execution with AI generation fallback for all commands."""
         cmd = command_class()
         
-        with patch(f'src.commands.{command_name}.ColorManager.warning') as mock_warning:
-            result = cmd.execute("", ai=True)
-            
-            assert result == 1
-            mock_warning.assert_called_once_with("AI functionality not yet implemented")
+        with patch.object(cmd, '_is_ai_configured', return_value=True):
+            with patch.object(cmd, '_generate_ai_message', return_value=0) as mock_generate:
+                result = cmd.execute(message="")
+                
+                assert result == 0
+                mock_generate.assert_called_once_with(None, False)
     
     @pytest.mark.parametrize("command_class,commit_type,main_func,command_name", COMMAND_TEST_DATA)
     def test_execute_commit_failure(self, command_class, commit_type, main_func, command_name):
         """Test execution when commit fails for all commands."""
         cmd = command_class()
         
-        with patch(f'src.commands.{command_name}.CommitCommand') as mock_commit_class:
-            mock_commit = MagicMock()
-            mock_commit.execute.return_value = 1
-            mock_commit_class.return_value = mock_commit
+        with patch.object(cmd, '_execute_manual_commit', return_value=1) as mock_execute:
+            result = cmd.execute("test message")
             
-            with patch(f'src.commands.{command_name}.ColorManager.error') as mock_error:
-                result = cmd.execute("test message")
-                
-                assert result == 1
-                mock_error.assert_called_once_with("Error al realizar commit")
+            assert result == 1
 
 
 class TestBasicConventionalCommitsCLI:
@@ -189,10 +165,12 @@ class TestBasicConventionalCommitsCLI:
         runner = CliRunner()
         
         # Test the actual behavior - Click doesn't propagate exit codes correctly in testing
-        result = runner.invoke(main_func, ["--ai"])
-        
-        # Check that AI warning message appears (functionality works)
-        assert "AI functionality not yet implemented" in result.output
+        # Mock _is_ai_configured to return False to test the fallback warning
+        with patch.object(command_class, '_is_ai_configured', return_value=False):
+            result = runner.invoke(main_func, ["--ai"])
+            
+            # Check that AI warning message appears (functionality works)
+            assert "IA no configurada" in result.output
     
     @pytest.mark.parametrize("command_class,commit_type,main_func,command_name", COMMAND_TEST_DATA)
     def test_cli_error_handling(self, command_class, commit_type, main_func, command_name):
@@ -200,10 +178,12 @@ class TestBasicConventionalCommitsCLI:
         runner = CliRunner()
         
         # Test with invalid input that should cause an error
-        result = runner.invoke(main_func, [""])
-        
-        # Check that error message appears (functionality works)
-        assert "Error al realizar commit" in result.output
+        # In current design empty message with AI disabled prints warning and returns 1
+        with patch.object(command_class, '_is_ai_configured', return_value=False):
+            result = runner.invoke(main_func, [""])
+            
+            # Check that error message appears
+            assert "IA no configurada" in result.output
 
 
 class TestBasicConventionalCommitsIntegration:
@@ -214,15 +194,8 @@ class TestBasicConventionalCommitsIntegration:
         """Test full workflow from CLI to commit for all commands."""
         runner = CliRunner()
         
-        with patch(f'src.commands.{command_name}.CommitCommand') as mock_commit_class:
-            mock_commit = MagicMock()
-            mock_commit.execute.return_value = 0
-            mock_commit_class.return_value = mock_commit
+        with patch.object(command_class, '_execute_manual_commit', return_value=0) as mock_execute:
+            result = runner.invoke(main_func, ["test message"])
             
-            with patch(f'src.commands.{command_name}.ColorManager.success') as mock_success:
-                result = runner.invoke(main_func, ["test message"])
-                
-                assert result.exit_code == 0
-                mock_commit_class.assert_called_once_with(commit_type)
-                mock_commit.execute.assert_called_once_with("test message", None, False)
-                mock_success.assert_called_once_with("Commit realizado exitosamente")
+            assert result.exit_code == 0
+            mock_execute.assert_called_once_with("test message", None, False)

--- a/tests/test_conventional_commits_specialized.py
+++ b/tests/test_conventional_commits_specialized.py
@@ -41,79 +41,55 @@ class TestSpecializedConventionalCommitsExecute:
         """Test successful execution for all specialized commands."""
         cmd = command_class()
         
-        with patch(f'src.commands.{command_name}.CommitCommand') as mock_commit_class:
-            mock_commit = MagicMock()
-            mock_commit.execute.return_value = 0
-            mock_commit_class.return_value = mock_commit
+        with patch.object(cmd, '_execute_manual_commit', return_value=0) as mock_execute:
+            result = cmd.execute("test message")
             
-            with patch(f'src.commands.{command_name}.ColorManager.success') as mock_success:
-                result = cmd.execute("test message")
-                
-                assert result == 0
-                mock_commit_class.assert_called_once_with(commit_type)
-                mock_commit.execute.assert_called_once_with("test message", None, False)
-                mock_success.assert_called_once_with("Commit realizado exitosamente")
+            assert result == 0
+            mock_execute.assert_called_once_with("test message", None, False)
     
     @pytest.mark.parametrize("command_class,commit_type,main_func,command_name", COMMAND_TEST_DATA)
     def test_execute_with_scope(self, command_class, commit_type, main_func, command_name):
         """Test execution with scope for all specialized commands."""
         cmd = command_class()
         
-        with patch(f'src.commands.{command_name}.CommitCommand') as mock_commit_class:
-            mock_commit = MagicMock()
-            mock_commit.execute.return_value = 0
-            mock_commit_class.return_value = mock_commit
+        with patch.object(cmd, '_execute_manual_commit', return_value=0) as mock_execute:
+            result = cmd.execute("test message", scope="pipeline")
             
-            with patch(f'src.commands.{command_name}.ColorManager.success') as mock_success:
-                result = cmd.execute("test message", scope="pipeline")
-                
-                assert result == 0
-                mock_commit.execute.assert_called_once_with("test message", "pipeline", False)
-                mock_success.assert_called_once_with("Commit realizado exitosamente")
+            assert result == 0
+            mock_execute.assert_called_once_with("test message", "pipeline", False)
     
     @pytest.mark.parametrize("command_class,commit_type,main_func,command_name", COMMAND_TEST_DATA)
     def test_execute_with_amend(self, command_class, commit_type, main_func, command_name):
         """Test execution with amend for all specialized commands."""
         cmd = command_class()
         
-        with patch(f'src.commands.{command_name}.CommitCommand') as mock_commit_class:
-            mock_commit = MagicMock()
-            mock_commit.execute.return_value = 0
-            mock_commit_class.return_value = mock_commit
+        with patch.object(cmd, '_execute_manual_commit', return_value=0) as mock_execute:
+            result = cmd.execute("test message", amend=True)
             
-            with patch(f'src.commands.{command_name}.ColorManager.success') as mock_success:
-                result = cmd.execute("test message", amend=True)
-                
-                assert result == 0
-                mock_commit.execute.assert_called_once_with("test message", None, True)
-                mock_success.assert_called_once_with("Commit realizado exitosamente")
-    
+            assert result == 0
+            mock_execute.assert_called_once_with("test message", None, True)
+
     @pytest.mark.parametrize("command_class,commit_type,main_func,command_name", COMMAND_TEST_DATA)
     def test_execute_with_ai_flag(self, command_class, commit_type, main_func, command_name):
-        """Test execution with AI flag (not implemented) for all specialized commands."""
+        """Test execution with AI fallback for all specialized commands."""
         cmd = command_class()
         
-        with patch(f'src.commands.{command_name}.ColorManager.warning') as mock_warning:
-            result = cmd.execute("", ai=True)
-            
-            assert result == 1
-            mock_warning.assert_called_once_with("AI functionality not yet implemented")
+        with patch.object(cmd, '_is_ai_configured', return_value=True):
+            with patch.object(cmd, '_generate_ai_message', return_value=0) as mock_generate:
+                result = cmd.execute(message="")
+                
+                assert result == 0
+                mock_generate.assert_called_once_with(None, False)
     
     @pytest.mark.parametrize("command_class,commit_type,main_func,command_name", COMMAND_TEST_DATA)
     def test_execute_commit_failure(self, command_class, commit_type, main_func, command_name):
         """Test execution when commit fails for all specialized commands."""
         cmd = command_class()
         
-        with patch(f'src.commands.{command_name}.CommitCommand') as mock_commit_class:
-            mock_commit = MagicMock()
-            mock_commit.execute.return_value = 1
-            mock_commit_class.return_value = mock_commit
+        with patch.object(cmd, '_execute_manual_commit', return_value=1) as mock_execute:
+            result = cmd.execute("test message")
             
-            with patch(f'src.commands.{command_name}.ColorManager.error') as mock_error:
-                result = cmd.execute("test message")
-                
-                assert result == 1
-                mock_error.assert_called_once_with("Error al realizar commit")
+            assert result == 1
 
 
 class TestSpecializedConventionalCommitsCLI:
@@ -185,10 +161,11 @@ class TestSpecializedConventionalCommitsCLI:
         runner = CliRunner()
         
         # Test the actual behavior - Click doesn't propagate exit codes correctly in testing
-        result = runner.invoke(main_func, ["--ai"])
-        
-        # Check that AI warning message appears (functionality works)
-        assert "AI functionality not yet implemented" in result.output
+        with patch.object(command_class, '_is_ai_configured', return_value=False):
+            result = runner.invoke(main_func, ["--ai"])
+            
+            # Check that AI warning message appears (functionality works)
+            assert "IA no configurada" in result.output
     
     @pytest.mark.parametrize("command_class,commit_type,main_func,command_name", COMMAND_TEST_DATA)
     def test_cli_error_handling(self, command_class, commit_type, main_func, command_name):
@@ -196,10 +173,11 @@ class TestSpecializedConventionalCommitsCLI:
         runner = CliRunner()
         
         # Test with invalid input that should cause an error
-        result = runner.invoke(main_func, [""])
-        
-        # Check that error message appears (functionality works)
-        assert "Error al realizar commit" in result.output
+        with patch.object(command_class, '_is_ai_configured', return_value=False):
+            result = runner.invoke(main_func, [""])
+            
+            # Check that error message appears (functionality works)
+            assert "IA no configurada" in result.output
 
 
 class TestSpecializedConventionalCommitsIntegration:
@@ -210,18 +188,11 @@ class TestSpecializedConventionalCommitsIntegration:
         """Test full workflow from CLI to commit for all specialized commands."""
         runner = CliRunner()
         
-        with patch(f'src.commands.{command_name}.CommitCommand') as mock_commit_class:
-            mock_commit = MagicMock()
-            mock_commit.execute.return_value = 0
-            mock_commit_class.return_value = mock_commit
+        with patch.object(command_class, '_execute_manual_commit', return_value=0) as mock_execute:
+            result = runner.invoke(main_func, ["test message"])
             
-            with patch(f'src.commands.{command_name}.ColorManager.success') as mock_success:
-                result = runner.invoke(main_func, ["test message"])
-                
-                assert result.exit_code == 0
-                mock_commit_class.assert_called_once_with(commit_type)
-                mock_commit.execute.assert_called_once_with("test message", None, False)
-                mock_success.assert_called_once_with("Commit realizado exitosamente")
+            assert result.exit_code == 0
+            mock_execute.assert_called_once_with("test message", None, False)
 
 
 class TestSpecializedConventionalCommitsSpecific:

--- a/tests/test_ggdocs.py
+++ b/tests/test_ggdocs.py
@@ -30,75 +30,51 @@ class TestDocsCommandExecute:
         """Test successful execution."""
         cmd = DocsCommand()
         
-        with patch('src.commands.ggdocs.CommitCommand') as mock_commit_class:
-            mock_commit = MagicMock()
-            mock_commit.execute.return_value = 0
-            mock_commit_class.return_value = mock_commit
+        with patch.object(cmd, '_execute_manual_commit', return_value=0) as mock_execute:
+            result = cmd.execute("update README")
             
-            with patch('src.commands.ggdocs.ColorManager.success') as mock_success:
-                result = cmd.execute("update README")
-                
-                assert result == 0
-                mock_commit_class.assert_called_once_with("docs")
-                mock_commit.execute.assert_called_once_with("update README", None, False)
-                mock_success.assert_called_once_with("Commit realizado exitosamente")
+            assert result == 0
+            mock_execute.assert_called_once_with("update README", None, False)
     
     def test_execute_with_scope(self):
         """Test execution with scope."""
         cmd = DocsCommand()
         
-        with patch('src.commands.ggdocs.CommitCommand') as mock_commit_class:
-            mock_commit = MagicMock()
-            mock_commit.execute.return_value = 0
-            mock_commit_class.return_value = mock_commit
+        with patch.object(cmd, '_execute_manual_commit', return_value=0) as mock_execute:
+            result = cmd.execute("update API docs", scope="api")
             
-            with patch('src.commands.ggdocs.ColorManager.success') as mock_success:
-                result = cmd.execute("update API docs", scope="api")
-                
-                assert result == 0
-                mock_commit.execute.assert_called_once_with("update API docs", "api", False)
-                mock_success.assert_called_once_with("Commit realizado exitosamente")
+            assert result == 0
+            mock_execute.assert_called_once_with("update API docs", "api", False)
     
     def test_execute_with_amend(self):
         """Test execution with amend."""
         cmd = DocsCommand()
         
-        with patch('src.commands.ggdocs.CommitCommand') as mock_commit_class:
-            mock_commit = MagicMock()
-            mock_commit.execute.return_value = 0
-            mock_commit_class.return_value = mock_commit
+        with patch.object(cmd, '_execute_manual_commit', return_value=0) as mock_execute:
+            result = cmd.execute("fix documentation", amend=True)
             
-            with patch('src.commands.ggdocs.ColorManager.success') as mock_success:
-                result = cmd.execute("fix documentation", amend=True)
-                
-                assert result == 0
-                mock_commit.execute.assert_called_once_with("fix documentation", None, True)
-                mock_success.assert_called_once_with("Commit realizado exitosamente")
+            assert result == 0
+            mock_execute.assert_called_once_with("fix documentation", None, True)
     
     def test_execute_with_ai_flag(self):
-        """Test execution with AI flag (not implemented)."""
+        """Test execution with AI generation fallback."""
         cmd = DocsCommand()
         
-        with patch('src.commands.ggdocs.ColorManager.warning') as mock_warning:
-            result = cmd.execute("", ai=True)
-            
-            assert result == 1
-            mock_warning.assert_called_once_with("AI functionality not yet implemented")
+        with patch.object(cmd, '_is_ai_configured', return_value=True):
+            with patch.object(cmd, '_generate_ai_message', return_value=0) as mock_generate:
+                result = cmd.execute(message="")
+                
+                assert result == 0
+                mock_generate.assert_called_once_with(None, False)
     
     def test_execute_commit_failure(self):
         """Test execution when commit fails."""
         cmd = DocsCommand()
         
-        with patch('src.commands.ggdocs.CommitCommand') as mock_commit_class:
-            mock_commit = MagicMock()
-            mock_commit.execute.return_value = 1
-            mock_commit_class.return_value = mock_commit
+        with patch.object(cmd, '_execute_manual_commit', return_value=1) as mock_execute:
+            result = cmd.execute("update docs")
             
-            with patch('src.commands.ggdocs.ColorManager.error') as mock_error:
-                result = cmd.execute("update docs")
-                
-                assert result == 1
-                mock_error.assert_called_once_with("Error al realizar commit")
+            assert result == 1
 
 
 class TestDocsCommandCLI:
@@ -166,20 +142,22 @@ class TestDocsCommandCLI:
         runner = CliRunner()
         
         # Test the actual behavior - Click doesn't propagate exit codes correctly in testing
-        result = runner.invoke(main, ["--ai"])
-        
-        # Check that AI warning message appears (functionality works)
-        assert "AI functionality not yet implemented" in result.output
+        with patch.object(DocsCommand, '_is_ai_configured', return_value=False):
+            result = runner.invoke(main, ["--ai"])
+            
+            # Check that AI warning message appears (functionality works)
+            assert "IA no configurada" in result.output
     
     def test_cli_error_handling(self):
         """Test CLI error handling."""
         runner = CliRunner()
         
         # Test with invalid input that should cause an error
-        result = runner.invoke(main, [""])
-        
-        # Check that error message appears (functionality works)
-        assert "Error al realizar commit" in result.output
+        with patch.object(DocsCommand, '_is_ai_configured', return_value=False):
+            result = runner.invoke(main, [""])
+            
+            # Check that error message appears (functionality works)
+            assert "IA no configurada" in result.output
 
 
 class TestDocsCommandIntegration:
@@ -189,15 +167,8 @@ class TestDocsCommandIntegration:
         """Test full workflow from CLI to commit."""
         runner = CliRunner()
         
-        with patch('src.commands.ggdocs.CommitCommand') as mock_commit_class:
-            mock_commit = MagicMock()
-            mock_commit.execute.return_value = 0
-            mock_commit_class.return_value = mock_commit
+        with patch.object(DocsCommand, '_execute_manual_commit', return_value=0) as mock_execute:
+            result = runner.invoke(main, ["update documentation"])
             
-            with patch('src.commands.ggdocs.ColorManager.success') as mock_success:
-                result = runner.invoke(main, ["update documentation"])
-                
-                assert result.exit_code == 0
-                mock_commit_class.assert_called_once_with("docs")
-                mock_commit.execute.assert_called_once_with("update documentation", None, False)
-                mock_success.assert_called_once_with("Commit realizado exitosamente")
+            assert result.exit_code == 0
+            mock_execute.assert_called_once_with("update documentation", None, False)


### PR DESCRIPTION
Resolves #22

- Se ajustó el `LoggingManager` para usar el `sys.stdout` nativo y se añadió un fixture global `clean_logging_handlers` en `conftest.py`. Esto elimina los tracebacks de `ValueError: I/O operation on closed file.` en `pytest`.
- Se corrigieron los mocks en todos los tests de los comandos de commits (`ggdocs`, `ggfeat`, `ggchore`, `ggperf`, `ggbuild`, `ggtest`, etc.), redirigiendo el mock a `_execute_manual_commit` en lugar de `CommitCommand`.
- Al corregir los tests, se evitó la instanciación secundaria de objetos y se eliminó el auto-committing indeseado que ensuciaba la rama local durante la ejecución de los tests.

**Épica Referencia**: #18