### PR TITLE
fix: resolve TypeError in logging integration test

### DIFF
--- a/src/core/utils/logging.py
+++ b/src/core/utils/logging.py
@@ -153,8 +153,9 @@ class LoggingManager:
         # Refresh handlers to prevent duplicate or stale closed handlers
         logger.handlers.clear()
         root_logger = logging.getLogger('gggit')
-        for handler in root_logger.handlers:
-            logger.addHandler(handler)
+        if isinstance(root_logger.handlers, list):
+            for handler in root_logger.handlers:
+                logger.addHandler(handler)
         
         # Prevent propagation to avoid duplicate logs
         logger.propagate = False


### PR DESCRIPTION
## Summary
This PR fixes a  that occurs in integration tests when the  attempts to iterate over the root logger's handlers while they are mocked.

## Changes
- Modified : Added a type check to ensure  is a list before attempting to iterate over it in .

## Test Plan
- Run ============================= test session starts ==============================
platform linux -- Python 3.12.11, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/mauro/novafuria/ggGit
configfile: pytest.ini
plugins: anyio-4.11.0, langsmith-0.4.31, asyncio-1.3.0, mock-3.15.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 19 items / 18 deselected / 1 selected

tests/test_integration.py .                                              [100%]

======================= 1 passed, 18 deselected in 0.01s ======================= to verify the test now passes.

Closes #30