### PR TITLE
test: isolate all TestGitIntegration tests

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -268,6 +268,12 @@ class TestConfigurationIntegration:
 class TestGitIntegration:
     """Integration tests for Git operations."""
     
+    @pytest.fixture(autouse=True)
+    def setup_working_directory(self, temp_git_repo, monkeypatch):
+        """Automatically change working directory to temp_git_repo for all tests in this class."""
+        monkeypatch.chdir(temp_git_repo)
+        self.repo_path = temp_git_repo
+    
     def test_git_interface_methods_exist(self, git_interface):
         """Test that all Git interface methods exist and are callable."""
         methods = [
@@ -288,13 +294,10 @@ class TestGitIntegration:
             method = getattr(git_interface, method_name)
             assert callable(method), f"Method {method_name} is not callable"
     
-    def test_git_interface_return_types(self, git_interface, temp_git_repo, monkeypatch):
+    def test_git_interface_return_types(self, git_interface):
         """Test that Git interface methods return correct types."""
-        # Isolate the test in the temporary repository to avoid host intrusion
-        monkeypatch.chdir(temp_git_repo)
-        
         # Create a dummy file to have something to stage and commit
-        dummy_file = temp_git_repo / "dummy.txt"
+        dummy_file = self.repo_path / "dummy.txt"
         dummy_file.write_text("dummy content")
         
         # Test boolean methods


### PR DESCRIPTION
## Summary
This PR refactors the `TestGitIntegration` class in `tests/test_integration.py` to ensure all its tests are isolated within a temporary Git repository by default.

## Changes
- Added a `setup_working_directory` fixture with `autouse=True` inside `TestGitIntegration`.
- This fixture uses `temp_git_repo` and `monkeypatch` to change the working directory to a temporary path for every test in the class.
- Simplified `test_git_interface_return_types` by removing the manual isolation logic added in the previous issue.

## Test Plan
- Run `pytest tests/test_integration.py` to verify all 19 tests pass in the isolated environment.

Closes #36