### PR TITLE
STORY-2.3.1b: Solución de Doble Comando para Sobreescritura de Tags en ggpl

### DIFF
--- a/.vibedoc/ideas/13d1 - Hipótesis: Sincronización automática de etiquetas en comando pull.md
+++ b/.vibedoc/ideas/13d1 - Hipótesis: Sincronización automática de etiquetas en comando pull.md
@@ -16,6 +16,12 @@ Para probar esta hipótesis en un escenario real que emule las etiquetas móvile
 
 - [[13d1a - Experimento: Implementación de descarga de tags automática en ggpl]]
 
+## Conclusiones y Evolución del Aprendizaje
+
+Durante la validación en caliente de esta hipótesis en producción, se descubrió una limitación crítica del comando `git pull --force` respecto a las etiquetas móviles, lo que obligó a evolucionar el modelo hacia una estrategia de doble comando:
+
+- [[13d1b - Reflexión: Limitaciones de git pull --force y solución de doble comando]]
+
 ## Referencias
 
 - [[13d - El comando ggpl no obtiene las etiquetas o tags del remoto]]

--- a/.vibedoc/ideas/13d1b - Reflexión: Limitaciones de git pull --force y solución de doble comando.md
+++ b/.vibedoc/ideas/13d1b - Reflexión: Limitaciones de git pull --force y solución de doble comando.md
@@ -1,0 +1,29 @@
+# 13d1b - Reflexión: Limitaciones de git pull --force y solución de doble comando
+
+## Contexto del Descubrimiento
+
+Durante las pruebas en condiciones reales tras fusionar la Story 2.3.1 (donde implementamos `git pull --all --tags --force --prune` por defecto para `ggpl`), se constató el siguiente comportamiento anómalo:
+*   `ggpl` descargaba con éxito los tags nuevos (como `v1.5.0` y `v1.5`).
+*   Sin embargo, **no sobreescribía los tags existentes** que se habían movido en el remoto (como el tag mayor `v1`), dejándolos localmente apuntados a commits obsoletos y sin reportar ningún error de ejecución.
+
+## Análisis de la Causa Raíz
+
+En la arquitectura interna de Git, `git pull` es un comando de alto nivel que realiza dos operaciones secuenciales: `git fetch` y `git merge` (o `rebase`). 
+
+Cuando ejecutamos `git pull --force`, el flag `--force` se asocia semánticamente a la fase de **merge** (forzando la integración de commits o pisando ramas locales), pero **no se propaga** con el comportamiento de "forzado de sobreescritura" a las referencias de etiquetas descargadas durante la fase interna de fetch. Git asume que las etiquetas son punteros estáticos del historial de commits, por lo que bloquea silenciosamente cualquier actualización de etiquetas locales preexistentes para evitar la pérdida de referencias locales históricas.
+
+Para que Git fuerce la sobreescritura de un tag móvil, se requiere explícitamente invocar el comando de bajo nivel `git fetch` pasándole de forma combinada los flags `--tags --force`.
+
+## La Solución de Doble Comando
+
+La única manera de garantizar la sincronía absoluta de los tags de forma segura y portable es implementar una **estrategia de doble comando** en el método `pull` de `GitInterface`:
+
+1.  **Paso 1: Pull de Commits y Ramas**: Ejecutar el `git pull` estándar de forma normal para integrar el código de la rama de trabajo.
+2.  **Paso 2: Fetch Forzado de Tags**: Si los parámetros `tags` o `force` están activos, ejecutar inmediatamente después un `git fetch --tags --force --prune` (o con `--all` si se especificó pull de todos los remotes). 
+
+Este paso complementario barre y machaca cualquier discrepancia local de etiquetas, forzando a que coincidan 1:1 con el estado exacto del servidor remoto y podando las eliminadas.
+
+## Referencias
+
+- [[13d1 - Hipótesis: Sincronización automática de etiquetas en comando pull]]
+- [[13d1a - Experimento: Implementación de descarga de tags automática en ggpl]]

--- a/.vibedoc/planning/iniciatives/INI-2-varios-bugs/epics/EPIC-2.3-optimizacion-comandos-core/EPIC-2.3-optimizacion-comandos-core.md
+++ b/.vibedoc/planning/iniciatives/INI-2-varios-bugs/epics/EPIC-2.3-optimizacion-comandos-core/EPIC-2.3-optimizacion-comandos-core.md
@@ -42,7 +42,10 @@ Se implementarán de forma iterativa cuatro historias de usuario que resuelvan c
 ## 📋 Historias de la Épica
 
 ### 🔄 Historias En Proceso
-1. **STORY-2.3.1**: [Sincronización de Etiquetas Robustas en ggpl](stories/STORY-2.3.1-sincronizacion-tags-ggpl.md)
+1. **STORY-2.3.1b**: [Solución de Doble Comando para Sobreescritura de Tags en ggpl](stories/STORY-2.3.1b-sobreescritura-tags-ggpl.md)
+
+### ✅ Historias Completadas
+- **STORY-2.3.1**: [Sincronización de Etiquetas Robustas en ggpl](stories/STORY-2.3.1-sincronizacion-tags-ggpl.md)
 
 ### 📋 Historias Pendientes
 2. **STORY-2.3.2**: Remoción del sistema de tracking de uso de IA

--- a/.vibedoc/planning/iniciatives/INI-2-varios-bugs/epics/EPIC-2.3-optimizacion-comandos-core/stories/STORY-2.3.1b-sobreescritura-tags-ggpl.md
+++ b/.vibedoc/planning/iniciatives/INI-2-varios-bugs/epics/EPIC-2.3-optimizacion-comandos-core/stories/STORY-2.3.1b-sobreescritura-tags-ggpl.md
@@ -1,0 +1,39 @@
+# [HISTORIA] - Solución de Doble Comando para Sobreescritura de Tags en ggpl
+
+## 🎯 Objetivo
+
+Corregir el bug funcional en el comando `ggpl` donde las etiquetas locales (tags) no se sobreescriben con las nuevas posiciones del remoto a pesar de usar `--force` en el pull. Se implementará una estrategia de doble comando ejecutando un `git fetch --tags --force --prune` complementario, garantizando que el espacio local refleje fielmente y de forma forzada los tags móviles de la CI.
+
+## 🌎 Contexto
+
+Durante la validación de la Story 2.3.1, se observó que `git pull --all --tags --force --prune` descarga los tags nuevos pero **no reemplaza** ni sobreescribe los tags locales existentes (como el tag mayor `v1`) cuando la CI los mueve en el remoto. Esto se debe a que en Git, el flag `--force` de `git pull` se interpreta en el contexto de la fusión (merge), ignorando el forzado de referencias en el fetch de tags. Este hallazgo se documenta en el Zettel [[13d1b - Reflexión: Limitaciones de git pull --force y solución de doble comando]].
+
+## 💡 Propuesta de Resolución
+
+Se propone modificar el método `pull` de `GitInterface` para que, si los parámetros `tags` o `force` están habilitados, ejecute un segundo subproceso complementario: `git fetch <remote> --tags --force --prune` (o con `--all` si aplica), forzando la sobreescritura de los tags locales y podando los eliminados en una sola transacción fluida.
+
+## 📦 Artefactos
+
+- 📦 **GitInterface Modificado**: `src/core/git.py`.
+- 📦 **Zettel de Reflexión**: `.vibedoc/ideas/13d1b - Reflexión: Limitaciones de git pull --force y solución de doble comando.md`.
+
+## 🔍 Criterios de Aceptación
+
+### Sobreescritura Real de Tags (Movable Tags):
+- Dado que un tag local `v1` apunta a un commit antiguo y en el remoto `v1` ha sido movido a un nuevo commit
+- Cuando se ejecute el comando `ggpl`
+- Entonces el tag local `v1` debe ser forzado a actualizarse, apuntando exactamente al mismo commit que en el remoto.
+
+### Poda de Tags:
+- Dado que un tag fue eliminado en el remoto
+- Cuando se ejecute el comando `ggpl`
+- Entonces el tag local correspondiente debe ser eliminado de forma automática.
+
+### Suite de Tests en Verde:
+- Dado que agregamos un paso de fetch complementario
+- Cuando se corran las pruebas unitarias y de integración
+- Entonces todas deben pasar en verde (580+ tests) y los mocks de `subprocess.run` deben validar el doble comando.
+
+🔗 Referencias
+
+- [[13d1b - Reflexión: Limitaciones de git pull --force y solución de doble comando]]

--- a/src/core/git.py
+++ b/src/core/git.py
@@ -878,7 +878,25 @@ class GitInterface:
                 cmd.append(branch)
 
             result = subprocess.run(cmd, capture_output=True, text=True)
-            return result.returncode == 0
+            if result.returncode == 0:
+                if tags or force or prune:
+                    fetch_cmd = ["git", "fetch"]
+                    if all_remotes:
+                        fetch_cmd.append("--all")
+                    elif remote:
+                        fetch_cmd.append(remote)
+
+                    if tags:
+                        fetch_cmd.append("--tags")
+                    if force:
+                        fetch_cmd.append("--force")
+                    if prune:
+                        fetch_cmd.append("--prune")
+
+                    fetch_result = subprocess.run(fetch_cmd, capture_output=True, text=True)
+                    return fetch_result.returncode == 0
+                return True
+            return False
 
         except subprocess.CalledProcessError as e:
             raise GitCommandError(f"Git pull failed: {e}")

--- a/src/core/git.py
+++ b/src/core/git.py
@@ -893,7 +893,9 @@ class GitInterface:
                     if prune:
                         fetch_cmd.append("--prune")
 
-                    fetch_result = subprocess.run(fetch_cmd, capture_output=True, text=True)
+                    fetch_result = subprocess.run(
+                        fetch_cmd, capture_output=True, text=True
+                    )
                     return fetch_result.returncode == 0
                 return True
             return False

--- a/tests/test_git_interface_extended.py
+++ b/tests/test_git_interface_extended.py
@@ -187,7 +187,10 @@ class TestGitInterfaceExtended:
                 )
 
                 assert result is True
-                mock_run.assert_called_once_with(
+                assert mock_run.call_count == 2
+                
+                # Verify first subprocess call (pull)
+                mock_run.assert_any_call(
                     [
                         "git",
                         "pull",
@@ -197,6 +200,20 @@ class TestGitInterfaceExtended:
                         "--prune",
                         "origin",
                         "main",
+                    ],
+                    capture_output=True,
+                    text=True,
+                )
+
+                # Verify second subprocess call (fetch for forced tag updates)
+                mock_run.assert_any_call(
+                    [
+                        "git",
+                        "fetch",
+                        "--all",
+                        "--tags",
+                        "--force",
+                        "--prune",
                     ],
                     capture_output=True,
                     text=True,

--- a/tests/test_git_interface_extended.py
+++ b/tests/test_git_interface_extended.py
@@ -188,7 +188,7 @@ class TestGitInterfaceExtended:
 
                 assert result is True
                 assert mock_run.call_count == 2
-                
+
                 # Verify first subprocess call (pull)
                 mock_run.assert_any_call(
                     [


### PR DESCRIPTION
Closes #44. Esta PR implementa la solución de doble comando en GitInterface.pull(), ejecutando un git fetch complementario con --tags --force --prune para forzar la actualización de etiquetas locales preexistentes y móviles que hayan cambiado en el remoto. También agrega el Zettel de Reflexión 13d1b y el manifiesto STORY-2.3.1b.